### PR TITLE
Implement user management with basic SIO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ hyper-tls = "0.5.0"
 log = "0.4.6"
 env_logger = "0.9.0"
 pretty_env_logger = "0.3.0"
-ring = "0.16.20"
+ring = "0.14"
 roxmltree = "0.6.0"
 serde = "1.0.92"
 serde_derive = "1.0.124"
@@ -22,5 +22,10 @@ tokio = { version = "1.13", features = ["full"] }
 xml-rs = "0.8.3"
 quick-xml = { version = "0.22", features = [ "serialize" ] }
 thiserror = "1.0.24"
-
-
+## SIO for Client.set_user()
+rust-argon2 = "0.8"
+rand = "0.8"
+sio = "0.2"
+[dev-dependencies]
+## Test async
+futures = "0.3"

--- a/src/minio/crypt.rs
+++ b/src/minio/crypt.rs
@@ -1,0 +1,126 @@
+use rand::Rng;
+use std::error::Error;
+use argon2::{Config, ThreadMode, Variant, Version};
+
+use std::io::Write;
+use sio::{Key, Nonce, Aad, EncWriter, DecWriter, Close};
+use sio::ring::{AES_256_GCM, CHACHA20_POLY1305};
+
+const ARGON2ID_AES_GCM: u8 = 0x00;
+const ARGON2ID_CHACHA20_POLY1305: u8 = 0x01;
+// const PBKDF2_AES_GCM: u8 = 0x02;
+
+const ARGON_CONFIG: argon2::Config = Config {
+    variant: Variant::Argon2id,
+    version: Version::Version13,
+    mem_cost: 64*1024,
+    time_cost: 1,
+    lanes: 4,
+    thread_mode: ThreadMode::Parallel,
+    secret: &[],
+    ad: &[],
+    hash_length: 32,
+};
+
+pub async fn sio_encrypt(
+    password: String,
+    data: Vec<u8>,
+    gcm: bool,
+) -> Result<Vec<u8>, Box<dyn Error>> {
+    // Random 32B of salt
+    let salt = rand::thread_rng().gen::<[u8; 32]>();
+    // Argon2id generated 32B array (from vector)
+    let argon_vec = argon2::hash_raw(password.as_bytes(), &salt, &ARGON_CONFIG).unwrap();
+    let mut argon_key = [0u8; 32];
+    for (place, element) in argon_key.iter_mut().zip(argon_vec.iter()) {
+        *place = *element;
+    }
+    // Random 8B of nonce prefix
+    let nbytes = rand::thread_rng().gen::<[u8; 8]>();
+    // Cipher-specific parameters
+    let (mut ciphertext, cid) = if gcm {
+        let nonce = Nonce::<AES_256_GCM>::new(nbytes);
+        let key = Key::new(argon_key);
+        let mut ciphertext: Vec<u8> = Vec::default();
+        let mut writer = EncWriter::new(&mut ciphertext, &key, nonce, Aad::from(b""));
+        writer.write_all(&data).unwrap();
+        writer.close().unwrap();
+        (ciphertext, ARGON2ID_AES_GCM)
+    } else {
+        let nonce = Nonce::<CHACHA20_POLY1305>::new(nbytes);
+        let key = Key::new(argon_key);
+        let mut ciphertext: Vec<u8> = Vec::default();
+        let mut writer = EncWriter::new(&mut ciphertext, &key, nonce, Aad::from(b""));
+        writer.write_all(&data).unwrap();
+        writer.close().unwrap();
+        (ciphertext, ARGON2ID_CHACHA20_POLY1305)
+    };
+    // Build final buffer
+    let mut encbuf = salt.clone().to_vec();
+    encbuf.push(cid);
+    encbuf.append(&mut nbytes.to_vec());
+    encbuf.append(&mut ciphertext);
+    Ok(encbuf)
+}
+
+pub async fn sio_decrypt(password: String, data: Vec<u8>) -> Result<Vec<u8>, Box<dyn Error>> {
+    let salt = &data[0..32].to_vec();
+    let cid = &data[32]; // unused for now, selector for ciphers
+    let gcm: bool = cid == &ARGON2ID_AES_GCM;
+    // Nonce 8B array from vec
+    let nonce_vec = data[33..41].to_vec();
+    let mut nbytes = [0u8; 8];
+    for (place, element) in nbytes.iter_mut().zip(nonce_vec.iter()) {
+        *place = *element;
+    }
+    let ctext = &data[41..].to_vec();
+    // Argon2id generated 32B array (from vector)
+    let argon_vec = argon2::hash_raw(password.as_bytes(), &salt, &ARGON_CONFIG).unwrap();
+    let mut argon_key = [0u8; 32];
+    for (place, element) in argon_key.iter_mut().zip(argon_vec.iter()) {
+        *place = *element;
+    }
+    // Decryption with selected cipher
+    let plaintext = if gcm {
+        let nonce = Nonce::<AES_256_GCM>::new(nbytes);
+        let key = Key::new(argon_key);
+        let mut plaintext: Vec<u8> = Vec::default();
+        let mut writer = DecWriter::new(&mut plaintext, &key, nonce, Aad::from(b""));
+        writer.write_all(&ctext).unwrap();
+        writer.close().unwrap();
+        plaintext
+    } else {
+        let nonce = Nonce::<CHACHA20_POLY1305>::new(nbytes);
+        let key = Key::new(argon_key);
+        let mut plaintext: Vec<u8> = Vec::default();
+        let mut writer = DecWriter::new(&mut plaintext, &key, nonce, Aad::from(b""));
+        writer.write_all(&ctext).unwrap();
+        writer.close().unwrap();
+        plaintext
+    };
+    Ok(plaintext)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::executor;
+    #[test]
+    fn verify_gcm_crypt() {
+        let password = "secret".to_owned();
+        let plaintext = "this is a string".as_bytes().to_vec();
+        let ciphertext =
+            executor::block_on(sio_encrypt(password.clone(), plaintext.clone(), true)).unwrap();
+        let decrypted = executor::block_on(sio_decrypt(password, ciphertext)).unwrap();
+        assert_eq!(plaintext, decrypted);
+    }
+    #[test]
+    fn verify_chacha_crypt() {
+        let password = "secret".to_owned();
+        let plaintext = "this is a string".as_bytes().to_vec();
+        let ciphertext =
+            executor::block_on(sio_encrypt(password.clone(), plaintext.clone(), false)).unwrap();
+        let decrypted = executor::block_on(sio_decrypt(password, ciphertext)).unwrap();
+        assert_eq!(plaintext, decrypted);
+    }
+}

--- a/src/minio/sign.rs
+++ b/src/minio/sign.rs
@@ -21,7 +21,6 @@ use hyper::header::{
     HeaderMap, HeaderName, HeaderValue, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, USER_AGENT,
 };
 use log::debug;
-use ring::hmac::HMAC_SHA256;
 use ring::{digest, hmac};
 use time::Tm;
 
@@ -143,8 +142,8 @@ fn string_to_sign(ts: &Tm, scope: &str, canonical_request: &str) -> String {
     .join("\n")
 }
 
-fn hmac_sha256(msg: &str, key: &[u8]) -> hmac::Tag {
-    let key = hmac::Key::new(HMAC_SHA256, key);
+fn hmac_sha256(msg: &str, key: &[u8]) -> hmac::Signature {
+    let key = hmac::SigningKey::new(&digest::SHA256, key);
     hmac::sign(&key, msg.as_bytes())
 }
 


### PR DESCRIPTION
MinIO uses the SecureIO library for its on-disk DARE data format,
with the underlying crypto engine also used to encrypt the JSON
data representing account information in-transit.
GoLang's SIO appears to be better maintained than the Rust variant;
but they do implement the same sequence-driven AEAD nonce semantic
and default to using the same buffer sizes, making their products
interoperable.

Unfortunately, minio-rs switched to using version 0.16 of the ring
crate also underpinning sio-rs but at version 0.14, producing a
dependency conflict.

Resolve the version dependency problem, rolling ring back to
v0.14.x and undoing the relevant changes to sign.rs.

With ring and sio-rs both compiling correctly, implement AES256GCM
and CHACHA20POLY1305 ciphers (solely with Argon2id keys for now).

Copy the salt, nonce, key, and writer composition semantics from
the Go MinIO admin codebase; clone the input and output buffer
handlers for decryption and encryption routines.

Implement tests for the crypto routines.

Expose the encryption routine to a set_user() function in the main
library, and create an S3Request structure which targets the admin
API's add-user endpoint for a PUT request delivering the encrypted
secret key information in the body along with the access key as a
header.

Testing:
  Manually tested against lab and production MinIO servers - user
account is created correctly.